### PR TITLE
=Pointer is initialized with obj

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -349,7 +349,7 @@ class Object(ParseResource):
 
     @property
     def as_pointer(self):
-        return Pointer(**{
+        return Pointer({
                 'className': self.__class__.__name__,
                 'objectId': self.objectId
                 })


### PR DESCRIPTION
I happen to have tested an object I retrieved from Parse doing this simple trick:

    for attr in dir(profile):
        print attr; 
        print getattr(profile, attr)

That's how I stumbled on the initialization problem in the as_pointer attribute.
Hope this helps.