### PR TITLE
Adds additional support for Relations.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -370,6 +370,55 @@ for post in posts_by_joe:
 **TODO**: Slicing of Querysets
 
 
+Relations
+---------
+
+You can associate multiple objects to a single object 
+by using a Relation.
+You then query against this subset of objects.
+
+~~~~~ {python}
+game = Game(name="3-way Battle")
+game.save()
+score1 = GameScore(player_name='Ronald', score=100)
+score2 = GameScore(player_name='Rebecca', score=140)
+score3 = GameScore(player_name='Sara', score=190)
+relation = game.relation('scores')
+relation.add([score1, score2, score3])
+~~~~~
+
+A Game gets added, three GameScores get added, and three relations
+are created associating the scores with the game.
+
+To retreive the related scores for a game, you use query() to get a
+Queryset for the relation.
+
+~~~~~ {python}
+scores = relation.query()
+for gamescore in scores:
+    print gamescore.player_name, gamescore.score
+~~~~~
+
+The Queryset can be manipulated like any Queryset.
+The query is limited to the objects previously added to the
+relation.
+
+~~~~~ {python}
+scores = relation.query().order_by('score', descending=True)
+for gamescore in scores:
+    print gamescore.player_name, gamescore.score
+~~~~~
+
+To remove objects from a relation, you use remove(). This example
+removes all the related objects.
+
+~~~~~ {python}
+scores = relation.query()
+for gamescore in scores:
+    relation.remove(gamescore)
+~~~~~
+
+
 Users
 -----
 

--- a/README.mkd
+++ b/README.mkd
@@ -376,6 +376,8 @@ Relations
 A Relation is field that contains references to multiple objects.
 You can query this subset of objects.
 
+(Note that Parse's relations are "one sided" and don't involve a join table.  [See the docs.](https://parse.com/docs/js/guide#relations-many-to-many))
+
 For example, if we have Game and GameScore classes, and one game
 can have multiple GameScores, you can use relations to associate
 those GameScores with a Game.

--- a/README.mkd
+++ b/README.mkd
@@ -373,9 +373,12 @@ for post in posts_by_joe:
 Relations
 ---------
 
-You can associate multiple objects to a single object 
-by using a Relation.
-You then query against this subset of objects.
+A Relation is field that contains references to multiple objects.
+You can query this subset of objects.
+
+For example, if we have Game and GameScore classes, and one game
+can have multiple GameScores, you can use relations to associate
+those GameScores with a Game.
 
 ~~~~~ {python}
 game = Game(name="3-way Battle")
@@ -388,7 +391,7 @@ relation.add([score1, score2, score3])
 ~~~~~
 
 A Game gets added, three GameScores get added, and three relations
-are created associating the scores with the game.
+are created associating the GameScores with the Game.
 
 To retreive the related scores for a game, you use query() to get a
 Queryset for the relation.
@@ -399,7 +402,6 @@ for gamescore in scores:
     print gamescore.player_name, gamescore.score
 ~~~~~
 
-The Queryset can be manipulated like any Queryset.
 The query is limited to the objects previously added to the
 relation.
 

--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -145,12 +145,12 @@ class Relation(ParseType):
         queries until we know what classes are on both sides
         of the relation.
 
-        If it's called via from_native, then, a later call to
+        If it's called via from_native, then a later call to
         with_parent() provides parent information.
 
         If it's called as Relation(), the relatedClassName is
         discovered either on the first added object, or
-        by probing the server to retrieve an object.
+        by querying the server to retrieve the schema.
         """
         # Name of the key on the parent object.
         self.key = None

--- a/parse_rest/test_relations.py
+++ b/parse_rest/test_relations.py
@@ -16,6 +16,7 @@ from itertools import chain
 
 from parse_rest.core import ResourceRequestNotFound
 from parse_rest.core import ResourceRequestBadRequest
+from parse_rest.core import ParseError
 from parse_rest.connection import register, ParseBatcher
 from parse_rest.datatypes import GeoPoint, Object, Function, Pointer, Relation
 from parse_rest.user import User
@@ -130,6 +131,35 @@ class TestRelation(unittest.TestCase):
         scores = self.rel.query()
         self.assertEqual(len(scores), 0)
 
+    def testWrongColumnForRelation(self):
+        """Should get a ParseError if we specify a relation on
+        a column that is not a relation.
+        """
+        with self.assertRaises(ParseError):
+            rel = self.game.relation("name")
+            bad = rel.query()
+        
+    def testWrongColumnForRelation(self):
+        """Should get a ParseError if we specify a relation on
+        a column that is not a relation.
+        """
+        with self.assertRaises(KeyError):
+            rel = self.game.relation("nonexistent")
+            bad = rel.query()
+    
+    def testRepr(self):
+        s = "*** %s ***" % (self.rel)
+        self.assertRegex(s, '<Relation where .+ for .+>')
+
+    def testWithParent(self):
+        """Rehydrating a relation from an instance on the server.
+        With_parent is called by relation() when the object was
+        retrieved from the server. This test is for code coverage.
+        """
+        game2 = Game.Query.get(objectId=self.game.objectId)
+        # self.assertTrue(hasattr(game2, 'scores'))
+        rel2 = game2.relation('scores')
+        # self.assertIsInstance(rel2, Relation)
 
 def run_tests():
     """Run all tests in the parse_rest package"""

--- a/parse_rest/test_relations.py
+++ b/parse_rest/test_relations.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+"""
+Contains unit tests for the Python Parse REST API wrapper
+"""
+from __future__ import print_function
+
+import os
+import sys
+import subprocess
+import unittest
+import datetime
+import six
+from itertools import chain
+
+from parse_rest.core import ResourceRequestNotFound
+from parse_rest.core import ResourceRequestBadRequest
+from parse_rest.connection import register, ParseBatcher
+from parse_rest.datatypes import GeoPoint, Object, Function, Pointer, Relation
+from parse_rest.user import User
+from parse_rest import query
+from parse_rest.installation import Push
+
+try:
+    import settings_local
+except ImportError:
+    sys.exit('You must create a settings_local.py file with APPLICATION_ID, ' \
+                 'REST_API_KEY, MASTER_KEY variables set')
+
+register(
+    getattr(settings_local, 'APPLICATION_ID'),
+    getattr(settings_local, 'REST_API_KEY'),
+    master_key=getattr(settings_local, 'MASTER_KEY')
+)
+
+GLOBAL_JSON_TEXT = """{
+    "applications": {
+        "_default": {
+            "link": "parseapi"
+        },
+        "parseapi": {
+            "applicationId": "%s",
+            "masterKey": "%s"
+        }
+    },
+    "global": {
+        "parseVersion": "1.1.16"
+    }
+}
+"""
+
+
+class Game(Object):
+    pass
+
+
+class GameScore(Object):
+    pass
+
+
+class TestRelation(unittest.TestCase):
+    def setUp(self):
+        self.score1 = GameScore(score=1337, player_name='John Doe', cheat_mode=False)
+        self.score2 = GameScore(score=1337, player_name='Jane Doe', cheat_mode=False)
+        self.score3 = GameScore(score=1337, player_name='Joan Doe', cheat_mode=False)
+        self.score4 = GameScore(score=1337, player_name='Jeff Doe', cheat_mode=False)
+        self.game = Game(name="foobar")
+        self.game.save()
+        self.rel = self.game.relation('scores')
+
+    def tearDown(self):
+        game_score = getattr(self.score1, 'score', None)
+        game_name = getattr(self.game, 'name', None)
+        if game_score:
+            ParseBatcher().batch_delete(GameScore.Query.filter(score=game_score))
+        if game_name:
+            ParseBatcher().batch_delete(Game.Query.filter(name=game_name))
+        
+    def testRelationsAdd(self):
+        """Add multiple objects to a relation."""
+        self.rel.add(self.score1)
+        scores = self.rel.query()
+        self.assertEqual(len(scores), 1)
+        self.assertEqual(scores[0].player_name, 'John Doe')
+
+        self.rel.add(self.score2)
+        scores = self.rel.query()
+        self.assertEqual(len(scores), 2)
+
+        self.rel.add([self.score3, self.score4])
+        scores = self.rel.query()
+        self.assertEqual(len(scores), 4)
+
+    def testRelationQueryLimitsToRelation(self):
+        """Relational query limits results to objects in the relation."""
+        self.rel.add([self.score1, self.score2])
+        gamescore3 = GameScore(score=1337)
+        gamescore3.save()
+        # score saved but not associated with the game
+        q = self.rel.query()
+        scores = q.filter(score__gte=1337)
+        self.assertEqual(len(scores), 2)
+
+    def testRemoval(self):
+        """Test if a specific object can be removed from a relation."""
+        self.rel.add([self.score1, self.score2, self.score3])
+        self.rel.remove(self.score1)
+        self.rel.remove(self.score2)
+        scores = self.rel.query()
+        self.assertEqual(scores[0].player_name, 'Joan Doe')
+
+    def testSchema(self):
+        """Retrieve a schema for the class."""
+        schema = Game.schema()
+        self.assertEqual(schema['className'], 'Game')
+        fields = schema['fields']
+        self.assertEqual(fields['scores']['type'], 'Relation')
+
+    def testWrongType(self):
+        """You can't add two different classes to a relation."""
+        with self.assertRaises(ResourceRequestBadRequest):
+            self.rel.add(self.score1)
+            self.rel.add(self.game)
+
+    def testNoTypeSet(self):
+        """Query can run before anything is added to the relation,
+        if the schema online has already defined the relation.
+        """
+        scores = self.rel.query()
+        self.assertEqual(len(scores), 0)
+
+
+def run_tests():
+    """Run all tests in the parse_rest package"""
+    tests = unittest.TestLoader().loadTestsFromNames(['parse_rest.tests'])
+    t = unittest.TextTestRunner(verbosity=1)
+    t.run(tests)
+
+if __name__ == "__main__":
+    # command line
+    unittest.main()


### PR DESCRIPTION
This adds support for Relations that is similar to
what's provided by the Javascript SDK.

It expands on recent work done to add support for
querying relations, and relies on that code to 
perform some functions. The specifics are as follows:

Adds Object.relation(key), which returns a Relation.
Adds Relation.add(obj) to add objects to relation.
Adds Relation.remove(obj) to remove objects from a relation.
Adds Relation.query() which gets a Queryset that queries objects
in the relation.  The query is limited to the set of objects that
has been added to the relation.
Adds method schema() to the Object class, to retrieve its schema from Parse.
Adds method schema_delete_field(key) to the Object class, to remove
a column from the schema. This is used for testing.
Adds a section to the documentation with an example of its use.

Testing is in test_relation.py.  They went a little long, so I
broke them out into a separate file.

All comments and critiques are appreciated.