### PR TITLE
Updated users endpoint to _User

### DIFF
--- a/parse_rest/user.py
+++ b/parse_rest/user.py
@@ -33,7 +33,7 @@ class User(ParseResource):
     A User is like a regular Parse object (can be modified and saved) but
     it requires additional methods and functionality
     '''
-    ENDPOINT_ROOT = '/'.join([API_ROOT, 'users'])
+    ENDPOINT_ROOT = '/'.join([API_ROOT, '_User'])
     PROTECTED_ATTRIBUTES = ParseResource.PROTECTED_ATTRIBUTES + [
         'username', 'sessionToken', 'emailVerified']
 


### PR DESCRIPTION
Old "user" endpoint was creating new class in my project instead of signing up user in default parse "User" class. "_User" will add user to parse's default User class instead of creating another class named "user".
