### PR TITLE
fix join on delete file

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -337,7 +337,7 @@ class File(ParseType, ParseBase):
             return response, lambda response_dict: None
 
     def delete(self, batch=False):
-        uri = "/".join(self.__class__.ENDPOINT_ROOT, self.name)
+        uri = "/".join([self.__class__.ENDPOINT_ROOT, self.name])
         response = self.__class__.DELETE(uri, batch=batch)
 
         if batch:


### PR DESCRIPTION
Hi,

Thanks for your work. I was trying to upload files and I got this error when I tried to delete one. 

```
Traceback (most recent call last):
  File "/mnt/scripts/parse_connector.py", line 38, in upload_image
    f.delete()
  File "/mnt/vendor/lib/python3.4/site-packages/parse_rest/datatypes.py", line 340, in delete
    uri = "/".join(self.__class__.ENDPOINT_ROOT, self.name)
TypeError: join() takes exactly one argument (2 given)
```